### PR TITLE
update the documentation after pypi move

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+[![PyPI version](https://badge.fury.io/py/simulchip.svg)](https://badge.fury.io/py/simulchip)
 
 A Python library for comparing NetrunnerDB decklists against your local card collection and generating print-ready PDF proxy sheets for missing cards.
 
@@ -36,19 +37,17 @@ The result is a clean, efficient Python library and CLI tool that does exactly w
 
 ## Installation
 
-### Option 1: Install from Source
-```bash
-git clone https://github.com/dfiru/simulchip.git
-cd simulchip
-pip install -e .
-```
+Install simulchip from PyPI using pip:
 
-### Option 2: Use as Library Dependency
 ```bash
-pip install git+https://github.com/dfiru/simulchip.git
+pip install simulchip
 ```
 
 After installation, you'll have both the Python library and the `simulchip` command-line tool available.
+
+**Requirements:**
+- Python 3.10 or higher
+- Compatible with Python 3.10, 3.11, 3.12, and 3.13
 
 ## Quick Start
 
@@ -276,6 +275,18 @@ Examples: `01001` (Noise), `30010` (Zahya), `33004` (Steelskin Scarring)
 
 ## Development
 
+### Development Installation
+
+For development work, clone the repository and install in editable mode:
+
+```bash
+git clone https://github.com/dfiru/simulchip.git
+cd simulchip
+pip install -e ".[dev]"
+```
+
+This installs all development dependencies including testing, linting, and documentation tools.
+
 ### Dependencies
 - `requests` - HTTP requests to NetrunnerDB API
 - `reportlab` - PDF generation
@@ -283,6 +294,7 @@ Examples: `01001` (Noise), `30010` (Zahya), `33004` (Steelskin Scarring)
 - `toml` - TOML file support
 - `typer` - CLI framework
 - `rich` - Terminal UI
+- `rich-pixels` - Terminal image rendering
 
 ### Documentation
 - **API Documentation**: [https://dfiru.github.io/simulchip/](https://dfiru.github.io/simulchip/)

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -4,34 +4,33 @@ Installation
 Requirements
 ------------
 
-* Python 3.10 or higher
+* Python 3.10 or higher (supports 3.10, 3.11, 3.12, 3.13)
 * pip package manager
 
 Install from PyPI
 -----------------
 
+The recommended way to install simulchip:
+
 .. code-block:: bash
 
    pip install simulchip
 
-Install from Source
--------------------
-
-.. code-block:: bash
-
-   git clone https://github.com/yourusername/simulchip.git
-   cd simulchip
-   pip install -e .
-
 Development Installation
 ------------------------
 
-For development with all tools:
+For development work, clone the repository and install in editable mode:
 
 .. code-block:: bash
 
-   git clone https://github.com/yourusername/simulchip.git
+   git clone https://github.com/dfiru/simulchip.git
    cd simulchip
+   pip install -e ".[dev]"
+
+For documentation development:
+
+.. code-block:: bash
+
    pip install -e ".[dev,docs]"
    pre-commit install
 


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description

✅ Documentation Updated for PyPI Installation

  README.md Changes:

  - Added PyPI badge to show package version
  - Main installation: Now shows pip install simulchip as primary method
  - Updated Python support: Added explicit 3.13 compatibility
  - Development section: Moved git clone instructions to development-only with proper [dev] extras

  API Documentation (docs/source/installation.rst) Changes:

  - Prioritized PyPI installation as "recommended way"
  - Updated Python support: Added 3.10-3.13 compatibility note
  - Streamlined development setup with proper dependency groups
  - Fixed GitHub URL: Updated from placeholder to actual dfiru/simulchip

  User Experience:

  - New users: Get simple pip install simulchip instruction
  - Developers: Clear separation with pip install -e ".[dev]" in development section
  - Documentation: Consistent installation guidance across README and docs

## 🔧 Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [ ] 🎨 Code style/refactoring
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test coverage improvement

## ✅ Contribution Guidelines
- [x] 📋 I have read and followed the [contribution guidelines](CONTRIBUTING.md)
- [x] 🧪 All tests pass and new functionality includes tests
- [x] 💎 Code passes all style checks (`make check`)

## 🔗 Related Issues

## 📌 Additional Notes
